### PR TITLE
Consolidate CI/CD packaging into matrix-based multi-platform job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,85 +43,30 @@ jobs:
         name: test-results
         path: TestResults/*.trx
 
-  package-windows-arm64:
-    name: Package for Windows ARM64
+  package:
+    name: Package ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: build
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Restore dependencies
-      run: dotnet restore src/FindMyContacts/FindMyContacts.csproj
-
-    - name: Publish for Windows ARM64
-      run: |
-        dotnet publish src/FindMyContacts/FindMyContacts.csproj \
-          --configuration Release \
-          --runtime win-arm64 \
-          --self-contained true \
-          --output ./publish/win-arm64 \
-          -p:PublishSingleFile=true \
-          -p:EnableCompressionInSingleFile=true \
-          -p:IncludeNativeLibrariesForSelfExtract=true
-
-    - name: Create archive
-      run: |
-        cd ./publish/win-arm64
-        zip -r ../../FindMyContacts-win-arm64.zip .
-
-    - name: Upload Windows ARM64 artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: FindMyContacts-win-arm64
-        path: FindMyContacts-win-arm64.zip
-        retention-days: 30
-
-  release:
-    name: Create Release Assets
-    runs-on: ubuntu-latest
-    needs: [build, package-windows-arm64]
     if: github.event_name == 'release'
-
-    steps:
-    - name: Download Windows ARM64 artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: FindMyContacts-win-arm64
-
-    - name: Upload release asset
-      uses: softprops/action-gh-release@v1
-      with:
-        files: FindMyContacts-win-arm64.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Additional build targets for reference
-  package-multi-platform:
-    name: Package Multi-Platform
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
 
     strategy:
       matrix:
         include:
           - runtime: win-x64
             name: Windows x64
+            extension: zip
+          - runtime: win-arm64
+            name: Windows ARM64
+            extension: zip
           - runtime: linux-x64
             name: Linux x64
+            extension: tar.gz
           - runtime: linux-arm64
             name: Linux ARM64
-          - runtime: osx-x64
-            name: macOS x64
+            extension: tar.gz
           - runtime: osx-arm64
             name: macOS ARM64
+            extension: tar.gz
 
     steps:
     - name: Checkout code
@@ -131,6 +76,15 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Get version from release tag
+      id: version
+      run: |
+        # Extract version from release tag (remove 'v' prefix if present)
+        VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION#v}"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Building version: $VERSION"
 
     - name: Restore dependencies
       run: dotnet restore src/FindMyContacts/FindMyContacts.csproj
@@ -144,20 +98,57 @@ jobs:
           --output ./publish/${{ matrix.runtime }} \
           -p:PublishSingleFile=true \
           -p:EnableCompressionInSingleFile=true \
-          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:IncludeNativeLibrariesForSelfExtract=true \
+          -p:Version=${{ steps.version.outputs.version }} \
+          -p:AssemblyVersion=${{ steps.version.outputs.version }} \
+          -p:FileVersion=${{ steps.version.outputs.version }} \
+          -p:InformationalVersion=${{ steps.version.outputs.version }}
 
     - name: Create archive
       run: |
+        VERSION="${{ steps.version.outputs.version }}"
         cd ./publish/${{ matrix.runtime }}
         if [[ "${{ matrix.runtime }}" == win-* ]]; then
-          zip -r ../../FindMyContacts-${{ matrix.runtime }}.zip .
+          zip -r "../../FindMyContacts-${VERSION}-${{ matrix.runtime }}.zip" .
         else
-          tar -czvf ../../FindMyContacts-${{ matrix.runtime }}.tar.gz .
+          tar -czvf "../../FindMyContacts-${VERSION}-${{ matrix.runtime }}.tar.gz" .
         fi
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: FindMyContacts-${{ matrix.runtime }}
-        path: FindMyContacts-${{ matrix.runtime }}.*
+        name: FindMyContacts-${{ steps.version.outputs.version }}-${{ matrix.runtime }}
+        path: FindMyContacts-${{ steps.version.outputs.version }}-${{ matrix.runtime }}.${{ matrix.extension }}
         retention-days: 30
+
+  release:
+    name: Upload Release Assets
+    runs-on: ubuntu-latest
+    needs: [build, package]
+    if: github.event_name == 'release'
+
+    steps:
+    - name: Get version from release tag
+      id: version
+      run: |
+        VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION#v}"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+        pattern: FindMyContacts-${{ steps.version.outputs.version }}-*
+
+    - name: List artifacts
+      run: find artifacts -type f
+
+    - name: Upload release assets
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          artifacts/**/*.zip
+          artifacts/**/*.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Refactored the CI/CD workflow to consolidate multiple platform-specific packaging jobs into a single matrix-based job that handles all target platforms (Windows x64/ARM64, Linux x64/ARM64, macOS ARM64). This reduces code duplication and improves maintainability.

## Key Changes
- **Consolidated packaging jobs**: Merged `package-windows-arm64` and `package-multi-platform` into a single `package` job using GitHub Actions matrix strategy
- **Added version extraction**: Implemented logic to extract version from release tags and inject it into published assemblies via MSBuild properties
- **Improved artifact naming**: Updated artifact names to include version information for better traceability (e.g., `FindMyContacts-1.0.0-win-x64.zip`)
- **Enhanced archive creation**: Updated archive naming to include version and use appropriate compression format per platform (zip for Windows, tar.gz for Linux/macOS)
- **Refactored release job**: Simplified the `release` job to download all versioned artifacts using a pattern and upload them in bulk
- **Removed macOS x64**: Dropped support for macOS x64 target (keeping only ARM64)

## Implementation Details
- Matrix includes runtime, display name, and file extension for each platform
- Version extraction handles both tagged releases (with optional 'v' prefix) and applies it to assembly metadata
- Archive creation uses conditional logic to select appropriate compression based on runtime platform
- Release job uses artifact download patterns to automatically collect all platform builds
- All packaging steps only run on release events, reducing unnecessary CI runs

https://claude.ai/code/session_016qv5APynTibZJCDgpYYpYy