### PR TITLE
Improve release asset upload to GitHub Releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -126,6 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, package]
     if: github.event_name == 'release'
+    permissions:
+      contents: write
 
     steps:
     - name: Get version from release tag
@@ -140,15 +142,19 @@ jobs:
       with:
         path: artifacts
         pattern: FindMyContacts-${{ steps.version.outputs.version }}-*
+        merge-multiple: true
 
     - name: List artifacts
-      run: find artifacts -type f
+      run: |
+        echo "Downloaded artifacts:"
+        find artifacts -type f -name "*.zip" -o -name "*.tar.gz" | sort
 
-    - name: Upload release assets
-      uses: softprops/action-gh-release@v1
+    - name: Upload release assets to GitHub Release
+      uses: softprops/action-gh-release@v2
       with:
         files: |
-          artifacts/**/*.zip
-          artifacts/**/*.tar.gz
+          artifacts/*.zip
+          artifacts/*.tar.gz
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add explicit `contents: write` permission for release job
- Use `merge-multiple: true` to flatten artifacts into single directory
- Update to softprops/action-gh-release@v2
- Add `fail_on_unmatched_files: true` to catch missing artifacts
- Simplify glob patterns for merged artifact structure

https://claude.ai/code/session_016qv5APynTibZJCDgpYYpYy